### PR TITLE
I8 return errors as warnings

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -139,7 +139,7 @@ target_get_trace <- function(name,
                                        xtype = xtype,
                                        method = method,
                                        span = span,
-                                       k = k))
+                                       k = k), stop_on_error = FALSE)
       list(name = jsonlite::unbox(nms[[i]]),
            model = model$output,
            raw = data_out(groups[[i]], xcol),

--- a/R/utils.R
+++ b/R/utils.R
@@ -2,12 +2,12 @@ with_warnings <- function(expr, stop_on_error = TRUE) {
   my_warnings <- NULL
 
   w_handler <- function(w) {
-    my_warnings <<- c(my_warnings, jsonlite::unbox(conditionMessage(w)))
+    my_warnings <<- unique(c(my_warnings, jsonlite::unbox(conditionMessage(w))))
     invokeRestart("muffleWarning")
   }
 
   e_handler_warn <- function(e) {
-    my_warnings <<- c(my_warnings, jsonlite::unbox(conditionMessage(e)))
+    my_warnings <<- unique(c(my_warnings, jsonlite::unbox(conditionMessage(e))))
     invokeRestart("muffleStop")
   }
 

--- a/inst/schema/DataSeries.schema.json
+++ b/inst/schema/DataSeries.schema.json
@@ -8,7 +8,7 @@
         "type": "string"
       },
       "model": {
-        "type": "object",
+        "type": ["object", "null"],
         "properties": {
           "x": {
             "type": "array",

--- a/inst/schema/DataSeries.schema.json
+++ b/inst/schema/DataSeries.schema.json
@@ -46,7 +46,7 @@
         "additionalProperties": false
       },
       "warnings": {
-        "type": "array",
+        "type": ["array", "null"],
         "items": {
           "type": "string"
         }

--- a/inst/schema/DataSeries.schema.json
+++ b/inst/schema/DataSeries.schema.json
@@ -42,17 +42,17 @@
             }
           }
         },
-        "warnings": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
         "required": ["x", "y"],
         "additionalProperties": false
+      },
+      "warnings": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
       }
     },
     "required": ["model", "raw", "warnings"],
-    "additionalProperties": true
+    "additionalProperties": false
   }
 }

--- a/inst/schema/DataSeries.schema.json
+++ b/inst/schema/DataSeries.schema.json
@@ -13,7 +13,7 @@
           "x": {
             "type": "array",
             "items": {
-              "type": ["number", "string"]
+              "type": ["number", "string", "null"]
             }
           },
           "y": {
@@ -32,7 +32,7 @@
           "x": {
             "type": "array",
             "items": {
-              "type": ["number", "string"]
+              "type": ["number", "string", "null"]
             }
           },
           "y": {
@@ -52,7 +52,7 @@
         }
       }
     },
-    "required": ["model", "raw", "warnings"],
+    "required": ["name", "model", "raw", "warnings"],
     "additionalProperties": false
   }
 }


### PR DESCRIPTION
If the spline model for a disaggregated trace fails, don't throw an error but just return a warning for that trace. Closes #8 