### PR TITLE
add schema for new endpoint

### DIFF
--- a/R/router.R
+++ b/R/router.R
@@ -95,7 +95,7 @@ get_individual <- function() {
                                      color = "string",
                                      filter = "string",
                                      linetype = "string"),
-    returning = porcelain::porcelain_returning_json())
+    returning = porcelain::porcelain_returning_json("Plotly"))
 }
 
 prune_inactive_sessions <- function(cache) {

--- a/inst/schema/Plotly.schema.json
+++ b/inst/schema/Plotly.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "x": {
+            "type": ["array", "null", "number"]
+          },
+          "y": {
+            "type": ["array", "null", "number"]
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "layout": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "warnings": {
+      "type": ["string", "null", "array"],
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": ["data", "layout", "warnings"],
+  "additionalProperties": false
+}

--- a/tests/testthat/test-read-individual.R
+++ b/tests/testthat/test-read-individual.R
@@ -22,7 +22,6 @@ test_that("GET /individual/<pidcol> returns 400 if pidcol not found", {
   expect_equal(res$status, 400)
   validate_failure_schema(res$body)
   body <- jsonlite::fromJSON(res$body)
-  str(body)
   expect_equal(body$errors[1, "detail"],
                "Id column 'pid' not found.")
 })
@@ -44,7 +43,9 @@ test_that("can get individual trajectories for uploaded dataset with xcol", {
   res <- router$call(make_req("GET",
                               "/dataset/testdataset/individual/pid/",
                               HTTP_COOKIE = cookie))
+
   expect_equal(res$status, 200)
+
   body <- jsonlite::fromJSON(res$body)
   expect_equal(nrow(body$data$data), 2)
   expect_equal(body$data$data$x[[1]], c(1, 3, 5, 7, 9))


### PR DESCRIPTION
Adds a partial schema for the `GET /individual` endpoint. The plotly data and layout objects are quite complicated, and we don't really need to validate them as they're generated by the `plotly` package. So this just includes some top level properties which will be useful for types in the front-end.