### PR TITLE
add /api/ prefix to routes

### DIFF
--- a/R/router.R
+++ b/R/router.R
@@ -31,6 +31,14 @@ build_routes <- function(cookie_key = plumber::random_cookie_key(),
   pr$registerHooks(plumber::session_cookie(cookie_key,
                                            name = "serovizr",
                                            path = "/"))
+
+  pr$filter("logger", function(req, res) {
+    logger::log_info(paste(as.character(Sys.time()), "-",
+                           req$REQUEST_METHOD, req$PATH_INFO, "-",
+                           req$HTTP_USER_AGENT, "@", req$REMOTE_ADDR, "\n"))
+    plumber::forward()
+  })
+
   pr$handle(get_root())
   pr$handle(get_version())
   pr$handle("POST", "/api/dataset/",

--- a/R/router.R
+++ b/R/router.R
@@ -31,10 +31,9 @@ build_routes <- function(cookie_key = plumber::random_cookie_key(),
   pr$registerHooks(plumber::session_cookie(cookie_key,
                                            name = "serovizr",
                                            path = "/"))
-
   pr$handle(get_root())
   pr$handle(get_version())
-  pr$handle("POST", "/dataset/",
+  pr$handle("POST", "/api/dataset/",
             function(req, res) target_post_dataset(req, res),
             serializer = plumber::serializer_unboxed_json(null = "null"))
   pr$handle(options_dataset())
@@ -48,7 +47,7 @@ build_routes <- function(cookie_key = plumber::random_cookie_key(),
 get_root <- function() {
   porcelain::porcelain_endpoint$new(
     "GET",
-    "/",
+    "/api/",
     target_get_root,
     returning = porcelain::porcelain_returning_json())
 }
@@ -56,28 +55,28 @@ get_root <- function() {
 get_version <- function() {
   porcelain::porcelain_endpoint$new(
     "GET",
-    "/version/",
+    "/api/version/",
     target_get_version,
     returning = porcelain::porcelain_returning_json("Version"))
 }
 
 get_dataset <- function() {
   porcelain::porcelain_endpoint$new(
-    "GET", "/dataset/<name>/",
+    "GET", "/api/dataset/<name>/",
     target_get_dataset,
     returning = porcelain::porcelain_returning_json("DatasetMetadata"))
 }
 
 delete_dataset <- function() {
   porcelain::porcelain_endpoint$new(
-    "DELETE", "/dataset/<name>/",
+    "DELETE", "/api/dataset/<name>/",
     target_delete_dataset,
     returning = porcelain::porcelain_returning_json())
 }
 
 options_dataset <- function() {
   porcelain::porcelain_endpoint$new(
-    "OPTIONS", "/dataset/<name>/",
+    "OPTIONS", "/api/dataset/<name>/",
     function(name) "OK",
     returning = porcelain::porcelain_returning_json())
 }
@@ -85,7 +84,7 @@ options_dataset <- function() {
 get_datasets <- function() {
   porcelain::porcelain_endpoint$new(
     "GET",
-    "/datasets/",
+    "/api/datasets/",
     target_get_datasets,
     returning = porcelain::porcelain_returning_json("DatasetNames"))
 }
@@ -93,7 +92,7 @@ get_datasets <- function() {
 get_trace <- function() {
   porcelain::porcelain_endpoint$new(
     "GET",
-    "/dataset/<name>/trace/<biomarker>/",
+    "/api/dataset/<name>/trace/<biomarker>/",
     target_get_trace,
     porcelain::porcelain_input_query(disaggregate = "string",
                                      filter = "string",
@@ -107,7 +106,7 @@ get_trace <- function() {
 get_individual <- function() {
   porcelain::porcelain_endpoint$new(
     "GET",
-    "/dataset/<name>/individual/<pidcol>/",
+    "/api/dataset/<name>/individual/<pidcol>/",
     target_get_individual,
     porcelain::porcelain_input_query(scale = "string",
                                      color = "string",

--- a/docker/smoke-test
+++ b/docker/smoke-test
@@ -8,7 +8,7 @@ wait_for()
     echo "waiting up to $TIMEOUT seconds for app"
     start_ts=$(date +%s)
     for i in $(seq $TIMEOUT); do
-        result="$(curl --write-out %{http_code} --silent --output /dev/null http://localhost:8888 2>/dev/null)"
+        result="$(curl --write-out %{http_code} --silent --output /dev/null http://localhost:8888/api/ 2>/dev/null)"
         if [[ $result -eq "200" ]]; then
             end_ts=$(date +%s)
             echo "App available after $((end_ts - start_ts)) seconds"

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -6,7 +6,7 @@ make_req <- function(verb = "GET",
                      ...) {
   req <- as.environment(list(...))
   req$REQUEST_METHOD <- toupper(verb)
-  req$PATH_INFO <- path
+  req$PATH_INFO <- paste0("/api", path)
   req$QUERY_STRING <- qs
   if (is.character(body)) {
     body <- charToRaw(body)

--- a/tests/testthat/test-router.R
+++ b/tests/testthat/test-router.R
@@ -10,7 +10,7 @@ test_that("GET /", {
   expect_equal(res_endpoint$data, res)
 
   router <- build_routes()
-  res_api <- router$request("GET", "/")
+  res_api <- router$request("GET", "/api/")
   expect_equal(res_api$status, 200)
   expect_equal(res_api$body, res_endpoint$body)
 })
@@ -20,7 +20,7 @@ test_that("GET /version", {
   expect_equal(res, jsonlite::unbox(as.character(packageVersion("serovizr"))))
 
   router <- build_routes()
-  res_api <- router$request("GET", "/version/")
+  res_api <- router$request("GET", "/api/version/")
   expect_equal(res_api$status, 200)
   body <- jsonlite::fromJSON(res_api$body)
   expect_equal(unclass(res), unclass(body$data))
@@ -135,6 +135,6 @@ test_that("GET /dataset/<name>/trace/<biomarker>", {
 
 test_that("requests without trailing slash are redirected", {
   router <- build_routes()
-  res_api <- router$request("GET", "/version")
+  res_api <- router$request("GET", "/api/version")
   expect_equal(res_api$status, 307)
 })


### PR DESCRIPTION
This is so that routes exposed by the `nginx` server correspond exactly to routes in the proxied service, to avoid uri re-writing and encoded path variables being decoded. See https://github.com/seroanalytics/seroviz/pull/21 for details.