### PR TITLE
endpoint to forcibly end a session, including deleting session files

### DIFF
--- a/R/router.R
+++ b/R/router.R
@@ -24,6 +24,8 @@ build_routes <- function(cookie_key = plumber::random_cookie_key(),
   pr$handle(get_datasets())
   pr$handle(get_trace())
   pr$handle(get_individual())
+  pr$handle(options_session())
+  pr$handle(delete_session())
   setup_docs(pr)
 }
 
@@ -79,6 +81,7 @@ prune_inactive_sessions <- function(cache) {
   old_sessions <- setdiff(subdirectories, active_sessions)
   if (length(old_sessions) > 0) {
     logger::log_info("Cleaning up expired sessions")
-    lapply(old_sessions, function(x) fs::dir_delete(file.path("uploads", x)))
+    lapply(old_sessions, function(x) unlink(file.path("uploads", x),
+                                            recursive = TRUE))
   }
 }

--- a/R/router.R
+++ b/R/router.R
@@ -81,7 +81,8 @@ prune_inactive_sessions <- function(cache) {
   old_sessions <- setdiff(subdirectories, active_sessions)
   if (length(old_sessions) > 0) {
     logger::log_info("Cleaning up expired sessions")
-    lapply(old_sessions, function(x) unlink(file.path("uploads", x),
-                                            recursive = TRUE))
+    lapply(old_sessions, function(x) {
+      unlink(file.path("uploads", x), recursive = TRUE)
+    })
   }
 }

--- a/R/routes.R
+++ b/R/routes.R
@@ -69,3 +69,17 @@ get_individual <- function() {
                                      page = "numeric"),
     returning = porcelain::porcelain_returning_json("Plotly"))
 }
+
+options_session <- function() {
+  porcelain::porcelain_endpoint$new(
+    "OPTIONS", "/api/session/",
+    function() "OK",
+    returning = porcelain::porcelain_returning_json())
+}
+
+delete_session <- function() {
+  porcelain::porcelain_endpoint$new(
+    "DELETE", "/api/session/",
+    target_delete_session,
+    returning = porcelain::porcelain_returning_json())
+}

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -2,6 +2,8 @@
 set.seed(1)
 dir.create("uploads")
 schema_root <- file.path(system.file("schema", package = "serovizr"))
+
+# test fixtures
 session_id <- generate_session_id()
 cookie_key <- plumber::random_cookie_key()
 session <- list(id = session_id)
@@ -10,4 +12,4 @@ encoded_cookie_val <- plumber:::encodeCookie(session,
 cookie <- plumber:::cookieToStr("serovizr", encoded_cookie_val)
 
 # Run after all tests
-withr::defer(fs::dir_delete("uploads"), teardown_env())
+#withr::defer(fs::dir_delete("uploads"), teardown_env())

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -12,4 +12,4 @@ encoded_cookie_val <- plumber:::encodeCookie(session,
 cookie <- plumber:::cookieToStr("serovizr", encoded_cookie_val)
 
 # Run after all tests
-#withr::defer(fs::dir_delete("uploads"), teardown_env())
+withr::defer(fs::dir_delete("uploads"), teardown_env())


### PR DESCRIPTION
To allow users to forcibly end a session, we should expose an endpoint that deletes their session cookie and any uploaded files.