### PR TITLE
remove /api prefix

### DIFF
--- a/R/router.R
+++ b/R/router.R
@@ -16,7 +16,7 @@ build_routes <- function(cookie_key = plumber::random_cookie_key(),
   pr$handle(get_version())
   # porcelain doesn't support multipart form content yet; for now wire this
   # endpoint up using plumber arguments instead
-  pr$handle("POST", "/api/dataset/", target_post_dataset,
+  pr$handle("POST", "/dataset/", target_post_dataset,
             serializer = plumber::serializer_unboxed_json(null = "null"))
   pr$handle(options_dataset())
   pr$handle(delete_dataset())

--- a/R/routes.R
+++ b/R/routes.R
@@ -1,7 +1,7 @@
 get_root <- function() {
   porcelain::porcelain_endpoint$new(
     "GET",
-    "/api/",
+    "/",
     target_get_root,
     returning = porcelain::porcelain_returning_json())
 }
@@ -9,28 +9,28 @@ get_root <- function() {
 get_version <- function() {
   porcelain::porcelain_endpoint$new(
     "GET",
-    "/api/version/",
+    "/version/",
     target_get_version,
     returning = porcelain::porcelain_returning_json("Version"))
 }
 
 get_dataset <- function() {
   porcelain::porcelain_endpoint$new(
-    "GET", "/api/dataset/<name>/",
+    "GET", "/dataset/<name>/",
     target_get_dataset,
     returning = porcelain::porcelain_returning_json("DatasetMetadata"))
 }
 
 delete_dataset <- function() {
   porcelain::porcelain_endpoint$new(
-    "DELETE", "/api/dataset/<name>/",
+    "DELETE", "/dataset/<name>/",
     target_delete_dataset,
     returning = porcelain::porcelain_returning_json())
 }
 
 options_dataset <- function() {
   porcelain::porcelain_endpoint$new(
-    "OPTIONS", "/api/dataset/<name>/",
+    "OPTIONS", "/dataset/<name>/",
     function(name) "OK",
     returning = porcelain::porcelain_returning_json())
 }
@@ -38,7 +38,7 @@ options_dataset <- function() {
 get_datasets <- function() {
   porcelain::porcelain_endpoint$new(
     "GET",
-    "/api/datasets/",
+    "/datasets/",
     target_get_datasets,
     returning = porcelain::porcelain_returning_json("DatasetNames"))
 }
@@ -46,7 +46,7 @@ get_datasets <- function() {
 get_trace <- function() {
   porcelain::porcelain_endpoint$new(
     "GET",
-    "/api/dataset/<name>/trace/<biomarker>/",
+    "/dataset/<name>/trace/<biomarker>/",
     target_get_trace,
     porcelain::porcelain_input_query(disaggregate = "string",
                                      filter = "string",
@@ -60,7 +60,7 @@ get_trace <- function() {
 get_individual <- function() {
   porcelain::porcelain_endpoint$new(
     "GET",
-    "/api/dataset/<name>/individual/<pidcol>/",
+    "/dataset/<name>/individual/<pidcol>/",
     target_get_individual,
     porcelain::porcelain_input_query(scale = "string",
                                      color = "string",
@@ -72,14 +72,14 @@ get_individual <- function() {
 
 options_session <- function() {
   porcelain::porcelain_endpoint$new(
-    "OPTIONS", "/api/session/",
+    "OPTIONS", "/session/",
     function() "OK",
     returning = porcelain::porcelain_returning_json())
 }
 
 delete_session <- function() {
   porcelain::porcelain_endpoint$new(
-    "DELETE", "/api/session/",
+    "DELETE", "/session/",
     target_delete_session,
     returning = porcelain::porcelain_returning_json())
 }

--- a/docker/smoke-test
+++ b/docker/smoke-test
@@ -8,7 +8,7 @@ wait_for()
     echo "waiting up to $TIMEOUT seconds for app"
     start_ts=$(date +%s)
     for i in $(seq $TIMEOUT); do
-        result="$(curl --write-out %{http_code} --silent --output /dev/null http://localhost:8888/api/ 2>/dev/null)"
+        result="$(curl --write-out %{http_code} --silent --output /dev/null http://localhost:8888/ 2>/dev/null)"
         if [[ $result -eq "200" ]]; then
             end_ts=$(date +%s)
             echo "App available after $((end_ts - start_ts)) seconds"

--- a/inst/spec.yaml
+++ b/inst/spec.yaml
@@ -7,9 +7,8 @@ info:
     name: GPL (>= 3)
     url: https://www.gnu.org/licenses/gpl-3.0.en.html
 servers:
-  - url: https://seroviz.seroanalytics.org/api
+  - url: https://seroviz.seroanalytics.org
   - url: http://localhost:8888
-basePath: "/api"
 paths:
   /:
     get:

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -6,7 +6,7 @@ make_req <- function(verb = "GET",
                      ...) {
   req <- as.environment(list(...))
   req$REQUEST_METHOD <- toupper(verb)
-  req$PATH_INFO <- paste0("/api", path)
+  req$PATH_INFO <- path
   req$QUERY_STRING <- qs
   if (is.character(body)) {
     body <- charToRaw(body)

--- a/tests/testthat/test-router.R
+++ b/tests/testthat/test-router.R
@@ -10,7 +10,7 @@ test_that("GET /", {
   expect_equal(res_endpoint$data, res)
 
   router <- build_routes()
-  res_api <- router$request("GET", "/api/")
+  res_api <- router$request("GET", "/")
   expect_equal(res_api$status, 200)
   expect_equal(res_api$body, res_endpoint$body)
 })
@@ -20,7 +20,7 @@ test_that("GET /version", {
   expect_equal(res, jsonlite::unbox(as.character(packageVersion("serovizr"))))
 
   router <- build_routes()
-  res_api <- router$request("GET", "/api/version/")
+  res_api <- router$request("GET", "/version/")
   expect_equal(res_api$status, 200)
   body <- jsonlite::fromJSON(res_api$body)
   expect_equal(unclass(res), unclass(body$data))
@@ -137,7 +137,7 @@ test_that("GET /dataset/<name>/trace/<biomarker>", {
 
 test_that("requests without trailing slash are redirected", {
   router <- build_routes()
-  res_api <- router$request("GET", "/api/version")
+  res_api <- router$request("GET", "/version")
   expect_equal(res_api$status, 307)
 })
 


### PR DESCRIPTION
For deploying via digital ocean, rather than the nginx reverse proxy, don't need the `api` prefix.